### PR TITLE
Twoots now upload

### DIFF
--- a/lib/postauth/account_screen.dart
+++ b/lib/postauth/account_screen.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 import 'package:twooter/main.dart';

--- a/lib/postauth/twoot_screen.dart
+++ b/lib/postauth/twoot_screen.dart
@@ -9,14 +9,22 @@ class TwootScreen extends StatelessWidget {
 
   const TwootScreen(this.user, {Key? key}) : super(key: key);
 
+  void sendTwoot(String title, String text) async {
+    print(title + ' : ' + text);
+
+    FirebaseFirestore.instance.runTransaction((Transaction transaction) async {
+      CollectionReference reference = FirebaseFirestore.instance.collection('posts');
+
+      await reference.add({"title": title, "text": text});
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final _formKey = GlobalKey<FormState>();
 
     final titleController = TextEditingController();
     final textController = TextEditingController();
-
-    String uid = user.uid;
 
     Form onLoadBody = Form(
           key: _formKey,
@@ -53,7 +61,9 @@ class TwootScreen extends StatelessWidget {
               // Submit Button
               ElevatedButton(
                 onPressed: () async {
-                  print(titleController.text + ' ' + textController.text);
+                  sendTwoot(titleController.text, textController.text);
+                  titleController.text = '';
+                  textController.text = '';
                 },
                 child: const Text('Twoot!'),
               ),


### PR DESCRIPTION
When we write a twoot, the `title` and `text` are uploaded to Cloud Firestore and stored in the `posts` collection. These posts then appear correctly in the `Feed` tab.